### PR TITLE
InputField Label covering pre-filled value on mount

### DIFF
--- a/frontend/src/components/common/InputField.js
+++ b/frontend/src/components/common/InputField.js
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import HelperText from "./HelperText";
 
@@ -152,7 +152,11 @@ const InputField = ({
 
   const inputRef = useRef();
 
-  const hasValue = inputRef.current?.value;
+  const [hasValue, setHasValue] = useState(false);
+
+  useEffect(() => {
+    setHasValue(Boolean(inputRef.current?.value));
+  }, [value]);
 
   return (
     <InputFieldRoot fullWidth={fullWidth}>


### PR DESCRIPTION
If the input has a value when it gets mounted, the label covers the value inside the `InputField`.